### PR TITLE
RPI2 rework

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -96,14 +96,13 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     PIC ?= 1
     NEW_DYNAREC := 1
     CFLAGS += -marm
-    ifeq ($(NEON), 1)
-      CFLAGS += -mfpu=neon -mfloat-abi=hard -DNEON
-    else
-      ifeq ($(VFP), 1)
-        CFLAGS += -mfpu=vfp -mfloat-abi=hard
-      else
-        CFLAGS += -mfpu=vfp -mfloat-abi=softfp
-      endif
+    ifneq ("$(filter armv5%,$(HOST_CPU))","")
+    	CFLAGS += -DARMv5_ONLY
+    	$(warning Using ARMv5_ONLY)
+    endif
+    ifneq ("$(filter armv6%,$(HOST_CPU))","")
+    	CFLAGS += -DARMv5_ONLY
+    	$(warning Using ARMv5_ONLY)
     endif
     $(warning Architecture "$(HOST_CPU)" not officially supported.')
   endif
@@ -119,8 +118,6 @@ RPIFLAGS ?= -fgcse-after-reload -finline-functions -fipa-cp-clone -funswitch-loo
 CFLAGS += $(OPTFLAGS) $(WARNFLAGS) $(RPIFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src -DM64P_PARALLEL 
 CXXFLAGS += -fvisibility-inlines-hidden $(RPIFLAGS) 
 
-CFLAGS += -DARMv5_ONLY
-CXXFLAGS += -DARMv5_ONLY
 LDLIBS += -lm 
 
 
@@ -257,8 +254,15 @@ endif
 CFLAGS += $(SDL_CFLAGS)
 LDLIBS += $(SDL_LDLIBS)
 
+ifeq ($(VC), 1)
+  CFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/vmcs_host/linux
+  LDLIBS += -L/opt/vc/lib -lEGL -lbcm_host -lvcos -lvchiq_arm
+  USE_GLES=1
+endif
+
 ifeq ($(USE_GLES), 1)
   CFLAGS += -DUSE_GLES
+  LDLIBS += -lGLESv2
   # OSD uses non-ES code and breaks attribs of video plugins
   OSD=0
 endif
@@ -278,9 +282,6 @@ ifeq ($(OSD), 1)
   LDLIBS += $(FREETYPE2_LDLIBS)
 
   # search for OpenGL libraries
-  ifeq ($(USE_GLES), 1)
-    GL_LDLIBS = -lGLESv2
-  endif
   ifeq ($(OS), OSX)
     GL_LDLIBS = -framework OpenGL
     GLU_LDLIBS = -framework OpenGL
@@ -562,8 +563,7 @@ targets:
 	@echo "    LIRC=1        == enable LIRC support"
 	@echo "    NO_ASM=1      == build without assembly (no dynamic recompiler or MMX/SSE code)"
 	@echo "    USE_GLES=1    == build against GLESv2 instead of OpenGL"
-	@echo "    NEON=1        == (ARM only) build for hard floating point environments with NEON FPU"
-	@echo "    VFP=1         == (ARM only) build for hard floating point environments"
+	@echo "    VC=1 	 == build against Broadcom Videocore GLESv2"
 	@echo "    SHAREDIR=path == extra path to search for shared data files"
 	@echo "    OPTFLAGS=flag == compiler optimization (default: -O3 -flto)"
 	@echo "    WARNFLAGS=flag == compiler warning levels (default: -Wall)"

--- a/src/api/vidext.c
+++ b/src/api/vidext.c
@@ -408,7 +408,7 @@ EXPORT m64p_error CALL VidExt_GL_SetAttribute(m64p_GLattr Attr, int Value)
     if (!SDL_WasInit(SDL_INIT_VIDEO))
         return M64ERR_NOT_INIT;
 	
-	return M64ERR_SUCCESS;
+    //return M64ERR_SUCCESS;
     for (i = 0; i < mapSize; i++)
     {
         if (GLAttrMap[i].m64Attr == Attr)

--- a/src/r4300/new_dynarec/linkage_arm.S
+++ b/src/r4300/new_dynarec/linkage_arm.S
@@ -17,17 +17,31 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	/*.cpu arm6
-	.fpu vfp*/
+	.cpu arm9tdmi
+#ifndef __ARM_NEON__
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__) && defined(__ARM_PCS_VFP))
+ 	.fpu vfp
+#else
+	.fpu softvfp
+#endif
+#else
+    	.fpu neon
+#endif
 	.eabi_attribute 20, 1
 	.eabi_attribute 21, 1
+#ifndef __ARM_NEON__
 	.eabi_attribute 23, 3
+#endif
 	.eabi_attribute 24, 1
 	.eabi_attribute 25, 1
 	.eabi_attribute 26, 2
+#ifndef __ARM_NEON__
+#if (defined(__VFP_FP__) && !defined(__SOFTFP__) && defined(__ARM_PCS_VFP))
+	.eabi_attribute 28, 1
+#endif
+#endif
 	.eabi_attribute 30, 6
 	.eabi_attribute 18, 4
-	.eabi_attribute 28, 1
 	.file	"linkage_arm.S"
 	.global extra_memory
 	.hidden extra_memory


### PR DESCRIPTION
RPI2 is an armv7 platform. -DARMv5_ONLY is no longer necessary. I fixed linkage_arm.S so we can use -mfpu=neon and -mfpu=vfp. Flags NEON and VFP are no longer necessary because linkage_arm.S uses gcc macros.

I also removed the context creation fix in vidext.c. Now it is possible to set multisampling or vsync. 
